### PR TITLE
Fix rating parse bug

### DIFF
--- a/src/main/java/mk/ukim/finki/connect/bootstrap/DataHolder.java
+++ b/src/main/java/mk/ukim/finki/connect/bootstrap/DataHolder.java
@@ -61,7 +61,7 @@ public class DataHolder {
                     Double.parseDouble(value[1]),
                     Double.parseDouble(value[2]),
                     value[3],
-                    Byte.parseByte(value[4])
+                    Byte.parseByte(value[4].trim())
             ));
         }
 
@@ -73,7 +73,7 @@ public class DataHolder {
                     Double.parseDouble(value[1]),
                     Double.parseDouble(value[2]),
                     value[3],
-                    Byte.parseByte(value[4])
+                    Byte.parseByte(value[4].trim())
             ));
         }
 


### PR DESCRIPTION
Parsing of rating would sometimes fail because of trailing white space, so now we trim the string before parsing